### PR TITLE
Fix Maven build issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>21</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <aws.sdk.version>2.25.1</aws.sdk.version>
-        <jsch.version>0.2.15</jsch.version>
+        <jsch.version>0.1.55</jsch.version>
         <slf4j.version>2.0.13</slf4j.version>
         <logback.version>1.5.6</logback.version>
     </properties>

--- a/src/main/java/com/example/ftpbackup/s3/S3Uploader.java
+++ b/src/main/java/com/example/ftpbackup/s3/S3Uploader.java
@@ -7,6 +7,7 @@ import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3ClientBuilder;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.S3Exception;
 
@@ -23,7 +24,7 @@ public final class S3Uploader implements AutoCloseable {
     }
 
     private S3Client buildClient(TransferConfig config) {
-        S3Client.Builder builder = S3Client.builder()
+        S3ClientBuilder builder = S3Client.builder()
                 .credentialsProvider(DefaultCredentialsProvider.create());
         config.region().ifPresent(builder::region);
         return builder.build();


### PR DESCRIPTION
## Summary
- update the JSch dependency to a version available in Maven Central
- correct the S3 client builder type to match the AWS SDK v2 API

## Testing
- `mvn -q -DskipTests package`


------
https://chatgpt.com/codex/tasks/task_e_68e2d2b330548324a06c3d99b7e12418